### PR TITLE
修改IIC调用API的名称

### DIFF
--- a/device/i2cdev.c
+++ b/device/i2cdev.c
@@ -25,7 +25,7 @@ void I2C_Device_Init(void) {
 	}
 }
 
-bool I2C_Device_Open(uint_least8_t index, I2C_Transaction *transaction) {
+bool I2C_Device_Transfer(uint_least8_t index, I2C_Transaction *transaction) {
 	I2C_Handle handle = NULL;
 	int_fast16_t result;
 	if (g_IsInitialized && (index < g_I2CCount)) {

--- a/device/i2cdev.h
+++ b/device/i2cdev.h
@@ -17,7 +17,7 @@ extern "C" {
 #endif
 
 void I2C_Device_Init(void);
-bool I2C_Device_Open(uint_least8_t index, I2C_Transaction *transaction);
+bool I2C_Device_Transfer(uint_least8_t index, I2C_Transaction *transaction);
 I2C_Handle I2C_Device_Close(uint_least8_t index);
 
 #ifdef __cplusplus

--- a/example/framework_test/cc3200/main.c
+++ b/example/framework_test/cc3200/main.c
@@ -31,7 +31,7 @@ int main(void) {
 		MAP_UtilsDelay(8000000);
 		GPIO_Device_Close(kREDLED);
 		MAP_UtilsDelay(8000000);
-		I2C_Device_Open(kTMP006, &transaction);
+		I2C_Device_Transfer(kTMP006, &transaction);
 		usManufacID = (unsigned short) (transaction.readBuf[0] << 8)
 				| transaction.readBuf[1];
 		printf("Manufacturer ID: 0x%04x\n\r", usManufacID);

--- a/port/cc3200/drive/i2cdrv.c
+++ b/port/cc3200/drive/i2cdrv.c
@@ -20,12 +20,12 @@
 #include "prcm.h"
 
 static void I2C_Drvice_Init(I2C_Handle handle);
-int_least16_t I2C_Drvice_transfer(I2C_Handle handle,
+int_least16_t I2C_Drvice_Ttransfer(I2C_Handle handle,
 		I2C_Transaction *transaction, uint32_t timeout);
 extern const uint_least8_t g_I2CCount;
 
 const I2C_FxnTable I2C_Drvice_fxnTable =
-		{ I2C_Drvice_Init, I2C_Drvice_transfer, };
+		{ I2C_Drvice_Init, I2C_Drvice_Ttransfer, };
 
 static void I2C_Drvice_Init(I2C_Handle handle) {
 	I2CMCU_HWAttrs const *hwAttrs = handle->hwAttrs;
@@ -110,7 +110,7 @@ static int I2CTransact(unsigned long baseAddr, unsigned long ulCmd) {
 	return true;
 }
 
-int_least16_t I2C_Drvice_transfer(I2C_Handle handle,
+int_least16_t I2C_Drvice_Ttransfer(I2C_Handle handle,
 		I2C_Transaction *transaction, uint32_t timeout) {
 	I2CMCU_HWAttrs const *hwAttrs = handle->hwAttrs;
 	I2CMCU_Object *object = handle->object;


### PR DESCRIPTION
因为之前使用I2C_Device_Open，进行IIC的数据获取，修改成I2C_Device_Transfer。